### PR TITLE
cbmc viewer windows patch

### DIFF
--- a/scripts/cbmc-viewer/reachable.py
+++ b/scripts/cbmc-viewer/reachable.py
@@ -5,6 +5,7 @@
 import re
 import subprocess
 import json
+import os
 
 
 def clean(s):
@@ -51,6 +52,17 @@ class Reachable:
             funcname = function['function']
             filename = function['file name']
             filename = srcloc.clean_path(filename)
+
+            # Declare as reachable functions only those functions in
+            # files under the source root.  This is the code under
+            # test, and this is the code we annotate and display in
+            # the report.
+            #
+            # srcloc.clean_path above returns paths relative to the
+            # source root for all files under the source root, and
+            # absolute paths for all other files.
+            if os.path.isabs(filename):
+                continue
 
             # goto-analyzer constructs useless file names for built-ins
             match = re.match('^.*(<[^>]*>)$', filename)

--- a/scripts/cbmc-viewer/srcloc.py
+++ b/scripts/cbmc-viewer/srcloc.py
@@ -114,7 +114,7 @@ class SourceLocation:
 
             # Compute file path relative to root
             # src_file may be an absolute path or relative to src_dir
-            path = ('' if src_file.startswith('/') else src_dir + '/') + src_file
+            path = os.path.join(src_dir, src_file)
             path = make_linux_normpath(path)
             path = self.strip_root(path)
 


### PR DESCRIPTION
First, use os.path.join to build absolute paths to source files.

Second, consider as reachable functions only those functions in files
under the source root.  Reports on Windows may otherwise include as
reachable some inlined functions in system header files that are
unused by the code under test.