### PR TITLE
Allow cbmc-viewer --srcdir to be a relative path.

### DIFF
--- a/scripts/cbmc-viewer/cbmc-viewer
+++ b/scripts/cbmc-viewer/cbmc-viewer
@@ -305,6 +305,9 @@ def main():
     parser = command_line_parser()
     args = parser.parse_args()
 
+    args.srcdir = os.path.abspath(args.srcdir) if args.srcdir else None
+    args.blddir = os.path.abspath(args.blddir) if args.blddir else None
+
     # blddir defaults to srcdir
     args.blddir = args.blddir or args.srcdir
 


### PR DESCRIPTION
Prior to this change, an error was possible if srcdir and blddir were
not given as absolute paths.  This change parses the command line
arguments and calls os.path.abspath on srcdir and blddir.