### PR TITLE
Make cbmc-viewer top-level exception handler pass on SystemExit.

### DIFF
--- a/scripts/cbmc-viewer/cbmc-viewer
+++ b/scripts/cbmc-viewer/cbmc-viewer
@@ -351,9 +351,11 @@ def main():
 ################################################################
 
 if __name__ == "__main__":
+    # pylint: disable=bare-except
     try:
         main()
-    # pylint: disable=bare-except
+    except SystemExit:
+        pass
     except:
         print('\ncbmc-viewer has encountered an error.\n')
         print(textwrap.fill(textwrap.dedent("""\


### PR DESCRIPTION
Top level exception handler traps on all exceptions and prints some debugging advice and a stack trace.  But argparse exits with SystemExit on "--help", and that is getting caught by the top level exception handler.  This patch just adds a pass on SystemExit to the try..except statement.