### PR TITLE
Fix cbmc-viewer configuration file extension.

### DIFF
--- a/scripts/cbmc-viewer/cbmc-viewer
+++ b/scripts/cbmc-viewer/cbmc-viewer
@@ -115,9 +115,9 @@ def command_line_parser():
     )
     parser.add_argument(
         '--config',
-        default='cbmc-viewer.py',
+        default='cbmc-viewer.json',
         metavar='FILE',
-        help='Python configuration file for cbmc-viewer.'
+        help='JSON configuration file for cbmc-viewer.'
     )
     return parser
 


### PR DESCRIPTION
The cbmc-viewer configuration file is a json file and not a python file.