### PR TITLE
Don't require xml source locations to include a function name

### DIFF
--- a/scripts/cbmc-viewer/viewer/locationt.py
+++ b/scripts/cbmc-viewer/viewer/locationt.py
@@ -148,7 +148,8 @@ def parse_xml_srcloc(sloc, root=None, asdict=False):
     # json output omits source locations in traces, maybe xml does, too
     if None in (sloc,
                 sloc.get('file'),
-                sloc.get('function'),
+                # source locations frequently omit function name
+                # sloc.get('function'),
                 sloc.get('line'),
                 sloc.get('working-directory')):
         logging.info("Found null srcloc in xml output from cbmc")


### PR DESCRIPTION
Source locations in cbmc xml output sometimes omit functions names.  This patch removes the function name from the list of items required in a source location when parsing a source location.  