### PR TITLE
Repair debian build for github actions

### DIFF
--- a/.github/workflows/debian/64bit_regression_tests.patch
+++ b/.github/workflows/debian/64bit_regression_tests.patch
@@ -1,0 +1,21 @@
+--- 64bit_regression_tests	2020-06-19 16:40:45.963502746 +0000
++++ 64bit_regression_tests_patch	2020-06-19 16:42:12.338994730 +0000
+@@ -147,14 +147,14 @@
+  --harness-type call-function --function test --treat-pointer-as-array arr --associated-array-size arr:sz
+  ^EXIT=0$
+  ^SIGNAL=0$
+--\[test.pointer_dereference.1\] line \d+ dereference failure: pointer NULL in arr\[\(signed( long)* int\)i\]: SUCCESS
+--\[test.pointer_dereference.2\] line \d+ dereference failure: pointer invalid in arr\[\(signed( long)* int\)i\]: SUCCESS
++-\[test.pointer_dereference.1\] line \d+ dereference failure: pointer invalid in arr\[\(signed( long)* int\)i\]: SUCCESS
++-\[test.pointer_dereference.2\] line \d+ dereference failure: pointer NULL in arr\[\(signed( long)* int\)i\]: SUCCESS
+ -\[test.pointer_dereference.3\] line \d+ dereference failure: deallocated dynamic object in arr\[\(signed( long)* int\)i\]: SUCCESS
+ -\[test.pointer_dereference.4\] line \d+ dereference failure: dead object in arr\[\(signed( long)* int\)i\]: SUCCESS
+ -\[test.pointer_dereference.5\] line \d+ dereference failure: pointer outside dynamic object bounds in arr\[\(signed( long)* int\)i\]: SUCCESS
+ -\[test.pointer_dereference.6\] line \d+ dereference failure: pointer outside object bounds in arr\[\(signed( long)* int\)i\]: SUCCESS
+-+\[test.pointer_dereference.1\] line \d+ dereference failure: pointer NULL in arr\[(\(signed( long)* int\))?i\]: SUCCESS
+-+\[test.pointer_dereference.2\] line \d+ dereference failure: pointer invalid in arr\[(\(signed( long)* int\))?i\]: SUCCESS
+++\[test.pointer_dereference.1\] line \d+ dereference failure: pointer invalid in arr\[(\(signed( long)* int\))?i\]: SUCCESS
+++\[test.pointer_dereference.2\] line \d+ dereference failure: pointer NULL in arr\[(\(signed( long)* int\))?i\]: SUCCESS
+ +\[test.pointer_dereference.3\] line \d+ dereference failure: deallocated dynamic object in arr\[(\(signed( long)* int\))?i\]: SUCCESS
+ +\[test.pointer_dereference.4\] line \d+ dereference failure: dead object in arr\[(\(signed( long)* int\))?i\]: SUCCESS
+ +\[test.pointer_dereference.5\] line \d+ dereference failure: pointer outside dynamic object bounds in arr\[(\(signed( long)* int\))?i\]: SUCCESS

--- a/.github/workflows/debian/Makefile
+++ b/.github/workflows/debian/Makefile
@@ -237,6 +237,9 @@ patch-debian-patches: $(SRCDIR)/debian
 	sed -i "s/<version>SUREFIRE<\/version>/<version>$$SUREFIRE_VERSION<\/version>/" \
 	  $(SRCDIR)/debian/patches/surefire
 
+	# Patch 64bit_regression_tests patch
+	cd $(SRCDIR)/debian/patches && patch < ../../../64bit_regression_tests.patch
+
 	# Refresh all patches with quilt
 	sudo apt-get -y install quilt
 	cd $(SRCDIR) && export QUILT_PATCHES=debian/patches && \

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -97,12 +97,8 @@ jobs:
       - name: Create the package
         run: |
           cp -r . /tmp/cbmc-${CBMC_VERSION}
-          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire /tmp
-          df -m /tmp
-          ls /tmp
+          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
           make -C /tmp GITHUB=1 STABLE=1 CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
-          df -m /tmp
-          ls /tmp
           mv /tmp/*.deb ${PACKAGE_STABLE_NAME}
 
       - name: Upload the package
@@ -137,13 +133,8 @@ jobs:
       - name: Create the package
         run: |
           cp -r . /tmp/cbmc-${CBMC_VERSION}
-          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire /tmp
-          df -m /tmp
-          ls /tmp
-          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog /tmp
+          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
           make -C /tmp GITHUB=1 STABLE= CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
-          df -m /tmp
-          ls /tmp
           mv /tmp/*.deb ${PACKAGE_LATEST_NAME}
 
       - name: Upload the package
@@ -178,12 +169,8 @@ jobs:
       - name: Create the package
         run: |
           cp -r . /tmp/cbmc-${CBMC_VERSION}
-          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire /tmp
-          df -m /tmp
-          ls /tmp
+          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
           make -C /tmp GITHUB=1 STABLE=1 CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
-          df -m /tmp
-          ls /tmp
           mv /tmp/*.deb ${PACKAGE_STABLE_NAME}
 
       - name: Upload the package
@@ -218,13 +205,8 @@ jobs:
       - name: Create the package
         run: |
           cp -r . /tmp/cbmc-${CBMC_VERSION}
-          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire /tmp
-          df -m /tmp
-          ls /tmp
-          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog /tmp
+          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
           make -C /tmp GITHUB=1 STABLE= CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
-          df -m /tmp
-          ls /tmp
           mv /tmp/*.deb ${PACKAGE_LATEST_NAME}
 
       - name: Upload the package

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -1,10 +1,12 @@
 name: CBMC Packages
 
-on:
-  # Build packages when new commits are pushed to develop
-  push:
-    branches:
-      - develop
+on: push
+
+#on:
+#  # Build packages when new commits are pushed to develop
+#  push:
+#    branches:
+#      - develop
 
 jobs:
   Tags:


### PR DESCRIPTION
This patch repair debian builds for github actions by patching the debian 64bit_regression_tests patch.  The issue is that cbmc output interchanged two lines in regression output, so the patch to the regression fails.  This patch the patch to the regression to make it succeed.

This now builds the latest  CBMC 5.12.1 on Ubuntu 16 and Ubuntu18 and passes all regression tests.  Some regression tests fail using this procedure to build on Ubuntu20.
